### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/containers/rails/Dockerfile
+++ b/docker/containers/rails/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.5.1
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
 RUN apt-get update -qq && apt-get install -y build-essential default-libmysqlclient-dev nodejs
 
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
2023年10月現在、docker compose buildに以下のエラーで失敗します。

```
=> ERROR [app  2/10] RUN apt-get update -qq && apt-get install -y build-essential default-libmysqlclient-dev nod  0.8s
------
 > [app  2/10] RUN apt-get update -qq && apt-get install -y build-essential default-libmysqlclient-dev nodejs:
0.772 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
0.773 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
0.773 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
0.773 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
0.773 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
0.774 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
0.775 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
failed to solve: process "/bin/sh -c apt-get update -qq && apt-get install -y build-essential default-libmysqlclient-dev nodejs" did not complete successfully: exit code: 100
```

この問題を修正するために、Dockerfileを修正しました。